### PR TITLE
Fix type_conversion, unused_label, and unitialized warnings in f_west.f

### DIFF
--- a/f_west.f
+++ b/f_west.f
@@ -54,10 +54,10 @@ c                       OR  OR  WA  WA  WA  WA  OR  WA
 c             IREGION:   1   2   3   4   5   6   7   8
       DATA (DFSUB(I),I=1,8)/'01','02','03','04','05','06','07','08'/ 
 c             Region 8 (Washington West coast) uses Region 6 (WA. West) coef.
-      data (r25(i),i=1,8)/   -2.0262D0, -1.7945d0, -2.0366d0,
-     >         -2.0811d0, -1.9868d0, -2.0151d0, -1.9475d0, -2.0151d0 /
-      data (r34(i),i=1,8)/ 5.2132d0, 5.1417d0, 5.1768d0 ,     
-     >          5.1156d0, 5.1654d0, 5.2413d0, 5.1427d0, 5.2413d0 /
+      data (r25(i),i=1,8)/   -2.0262E0, -1.7945e0, -2.0366e0,
+     >         -2.0811e0, -1.9868e0, -2.0151e0, -1.9475e0, -2.0151e0 /
+      data (r34(i),i=1,8)/ 5.2132e0, 5.1417e0, 5.1768e0 ,
+     >          5.1156e0, 5.1654e0, 5.2413e0, 5.1427e0, 5.2413e0 /
 
 c                               Region modifications to coefficients
       FR25=f(25)
@@ -116,20 +116,20 @@ c                                        U6=A3 (bounds: 1.005-100)
          if(U6 .gt. 100.0d0) U6=100.0d0
 
 c                                         Define geometric parameters
-      R1= dexp(U1)/ (1.0d0 + dexp(U1))                             
-      R2= dexp(U2)/ (1.0d0 + dexp(U2))                             
-      R3= dexp(U3)/ (1.0d0 + dexp(U3))                             
-      R4= dexp(U4)/ (1.0d0 + dexp(U4))                             
-      R5= 0.5d0 + 0.5d0*dexp(U5)/ (1.0d0 + dexp(U5))                        
+      R1= REAL(dexp(U1)/ (1.0d0 + dexp(U1)))
+      R2= REAL(dexp(U2)/ (1.0d0 + dexp(U2)))
+      R3= REAL(dexp(U3)/ (1.0d0 + dexp(U3)))
+      R4= REAL(dexp(U4)/ (1.0d0 + dexp(U4)))
+      R5= REAL(0.5d0 + 0.5d0*dexp(U5)/ (1.0d0 + dexp(U5)))
 
-      A3=U6
-      RHI1 =  dexp(U7) / ( 1.0d0 + dexp(U7) )
+      A3=REAL(U6)
+      RHI1 =  REAL(dexp(U7) / ( 1.0d0 + dexp(U7) ))
       if (RHI1.gt. 0.5) RHI1=0.5
 
-      RHLONGI= U9    
+      RHLONGI= REAL(U9)
       RHI2 = RHI1 + RHLONGI
 
-      RHC = RHI2 + (1.0 - RHI2) * dexp(U8)/( 1.0d0 + dexp(U8))
+      RHC = REAL(RHI2 + (1.0 - RHI2) * dexp(U8)/( 1.0d0 + dexp(U8)))
 
 C     PUT COEFFICIENTS INTO AN ARRAY FOR EASIER PASSING
       RFLW(1) = R1
@@ -198,10 +198,10 @@ c                       OR  OR  WA  WA  WA  WA  OR  WA
 c             IREGION:   1   2   3   4   5   6   7   8
       DATA (WHSUB(I),I=1,8)/'01','02','03','04','05','06','07','08'/ 
 c             Region 2 (Oregon West Valley) uses Region 3 (Or. EV) coef.
-      data (r25(i),i=1,8)/  -7.511d0, -7.687d0, -7.224d0, 
-     >              -7.355d0, -7.632d0, -7.646d0, -7.687d0, -7.911d0/
-      data (r34(i),i=1,8)/ -1.215d0, -1.355d0, -1.177d0,
-     >              -1.373d0, -1.398d0, -1.188d0, -1.355d0, -1.449d0 /
+      data (r25(i),i=1,8)/  -7.511e0, -7.687e0, -7.224e0,
+     >              -7.355e0, -7.632e0, -7.646e0, -7.687e0, -7.911e0/
+      data (r34(i),i=1,8)/ -1.215e0, -1.355e0, -1.177e0,
+     >              -1.373e0, -1.398e0, -1.188e0, -1.355e0, -1.449e0 /
 
 c                               Region modifications to coefficients
       FR25=f(25)
@@ -223,7 +223,7 @@ c                                                                RHI1
       U7 = F(13) + f(14)*( 1.0d0 - exp(F(15)*HTTOT))                     
       if (U7.lt. -7.0d0) U7=-7.0d0                               
       if (U7.gt.  7.0d0) U7= 7.0d0                
-      RHI1 =  dexp(U7) / ( 1.0d0 + dexp(U7) )
+      RHI1 =  REAL(dexp(U7) / ( 1.0d0 + dexp(U7) ))
       if (RHI1.gt. 0.5) RHI1=0.5
                              
 c                                                                RHLONGI
@@ -268,18 +268,18 @@ c                                        U6=A3 (bounds: 1.005-100)
          if(U6 .gt. 100.0d0) U6=100.0d0
 
 c                                         Define geometric parameters
-      R1= dexp(U1)/ (1.0d0 + dexp(U1))                             
-      R2= dexp(U2)/ (1.0d0 + dexp(U2))                             
-      R3= dexp(U3)/ (1.0d0 + dexp(U3))                             
-      R4= dexp(U4)/ (1.0d0 + dexp(U4))                             
-      R5= 0.5d0 + 0.5d0*dexp(U5)/ (1.0d0 + dexp(U5))                        
+      R1= REAL(dexp(U1)/ (1.0d0 + dexp(U1)))
+      R2= REAL(dexp(U2)/ (1.0d0 + dexp(U2)))
+      R3= REAL(dexp(U3)/ (1.0d0 + dexp(U3)))
+      R4= REAL(dexp(U4)/ (1.0d0 + dexp(U4)))
+      R5= REAL(0.5d0 + 0.5d0*dexp(U5)/ (1.0d0 + dexp(U5)))
 
-      A3=U6
+      A3=REAL(U6)
 
-      RHLONGI= U9    
+      RHLONGI= REAL(U9)
       RHI2 = RHI1 + RHLONGI
 
-      RHC = RHI2 + (1.0 - RHI2) * dexp(U8)/( 1.0d0 + dexp(U8))
+      RHC = REAL(RHI2 + (1.0 - RHI2) * dexp(U8)/( 1.0d0 + dexp(U8)))
 
 C     PUT COEFFICIENTS INTO AN ARRAY FOR EASIER PASSING
       RFLW(1) = R1
@@ -336,6 +336,10 @@ c              common SF_A provides DBHOB(ob), Total height and D=DBHOB(ib)
 
 
 c                               Region modifications to coefficients
+c              Red cedar has no regional coefficients, so GEOSUB is
+c              unused here (SHP_W3 and SHP_W4 look up r25/r34 by it).
+c              It stays in the argument list because SF_SHP calls
+c              SHP_W3, SHP_W4 and SHP_W5 through one uniform signature.
 
       DMEDIAN = .11*(HTTOT-4.5)**( 1.08 + 0.0006*HTTOT)
       DFORM = DBHOB/DMEDIAN -1.0d0
@@ -344,7 +348,7 @@ c                                                                RHI1
       U7 = F(13)  +F(15)*DFORM                    
        if (U7.lt. -7.0d0) U7=-7.0d0                               
        if (U7.gt.  1.0d0) U7= 1.0d0                
-      RHI1 =  dexp(U7) / ( 1.0d0 + dexp(U7) )
+      RHI1 =  REAL(dexp(U7) / ( 1.0d0 + dexp(U7) ))
                              
 c                                                                RHLONGI
       U9A = f(17) + f(18)*log(HTTOT) 
@@ -387,18 +391,18 @@ c                                        U6=A3 (bounds: 1.005-100)
          if(U6 .gt. 100.0d0) U6=100.0d0
 
 c                                         Define geometric parameters
-      R1= dexp(U1)/ (1.0d0 + dexp(U1))                             
-      R2= dexp(U2)/ (1.0d0 + dexp(U2))                             
-      R3= dexp(U3)/ (1.0d0 + dexp(U3))                             
-      R4= dexp(U4)/ (1.0d0 + dexp(U4))                             
-      R5= 0.5d0 + 0.5d0*dexp(U5)/ (1.0d0 + dexp(U5))                        
+      R1= REAL(dexp(U1)/ (1.0d0 + dexp(U1)))
+      R2= REAL(dexp(U2)/ (1.0d0 + dexp(U2)))
+      R3= REAL(dexp(U3)/ (1.0d0 + dexp(U3)))
+      R4= REAL(dexp(U4)/ (1.0d0 + dexp(U4)))
+      R5= REAL(0.5d0 + 0.5d0*dexp(U5)/ (1.0d0 + dexp(U5)))
 
-      A3=U6
+      A3=REAL(U6)
 
-      RHLONGI= U9    
+      RHLONGI= REAL(U9)
       RHI2 = RHI1 + RHLONGI
 
-      RHC = RHI2 + (1.0 - RHI2) * dexp(U8)/( 1.0d0 + dexp(U8))
+      RHC = REAL(RHI2 + (1.0 - RHI2) * dexp(U8)/( 1.0d0 + dexp(U8)))
 
 C     PUT COEFFICIENTS INTO AN ARRAY FOR EASIER PASSING
       RFLW(1) = R1
@@ -469,8 +473,8 @@ c                             define heights h1 and h2 with h2 > h1
 c                                         both heights are above BH
        t3=(h1-bh)/(HTTOT-bh)
        t4=(h2-bh)/(HTTOT-bh)                                
-       CORR = exp( q1*(t4-t3) + q2*(t4*t4-t3*t3)/2.0D0
-     >                  +q3*(t4*t4*t4 - t3*t3*t3)/3.0D0)     
+       CORR = REAL(exp( q1*(t4-t3) + q2*(t4*t4-t3*t3)/2.0D0
+     >                  +q3*(t4*t4*t4 - t3*t3*t3)/3.0D0))
        GO TO 100
       endif
 
@@ -478,8 +482,8 @@ c                                         both heights are above BH
 c                                              h1 < Bh  and h2 > BH
          t3=(h2-bh)/(HTTOT-bh)                             
          T2 = (BH-H1)/BH    
-         CORR = q5*exp( q4*t2 + q1*t3 +q2*t3*t3/2.0d0 
-     >                    +q3*t3**3 / 3.0d0 )       
+         CORR = REAL(q5*exp( q4*t2 + q1*t3 +q2*t3*t3/2.0d0
+     >                    +q3*t3**3 / 3.0d0 ))
          go to 100
         endif
 
@@ -617,7 +621,7 @@ c                                          EQN 2   Y
            Y=0.999999D0 
       ENDIF
 c                                          EQN 3  ZETA   
-      Z  = GAMMA + DELTA*LOG(Y/(1.0d0-Y))
+      Z  = REAL(GAMMA + DELTA*LOG(Y/(1.0d0-Y)))
 
       RETURN
 
@@ -643,7 +647,7 @@ c                                          reverses the Sb transform
        Y = exp(ylogit)/(1.0d0 + exp(ylogit))
                          
        X = MU + LAMDA*Y                                             
-       DIBact = X * DIBmod
+       DIBact = REAL(X * DIBmod)
 
       RETURN
       END             
@@ -739,7 +743,7 @@ c                                          EQN 2   Y
            Y=0.999999D0 
       ENDIF
 c                                          EQN 3  ZETA   
-      Z  = GAMMA + DELTA*LOG(Y/(1.0d0-Y))
+      Z  = REAL(GAMMA + DELTA*LOG(Y/(1.0d0-Y)))
 
       RETURN
 
@@ -764,7 +768,7 @@ c                                          reverses the Sb transform
 120    YLOGIT = (Z - GAMMA)/DELTA
        Y = exp(ylogit)/(1.0D0 + exp(ylogit))           
        X = MU + LAMDA*Y                                             
-       DIBact = X * DIBmod
+       DIBact = REAL(X * DIBmod)
 
       RETURN
       END             
@@ -859,7 +863,7 @@ c                                          EQN 2   Y
            Y=0.999999D0 
       ENDIF
 c                                          EQN 3  ZETA   
-      Z  = GAMMA + DELTA*LOG(Y/(1.0d0-Y))
+      Z  = REAL(GAMMA + DELTA*LOG(Y/(1.0d0-Y)))
 
       RETURN
 
@@ -884,7 +888,7 @@ c                                          reverses the Sb transform
 120    YLOGIT = (Z - GAMMA)/DELTA
        Y = exp(ylogit)/(1.0D0 + exp(ylogit))           
        X = MU + LAMDA*Y                                             
-       DIBact = X * DIBmod
+       DIBact = REAL(X * DIBmod)
 
       RETURN
       END             
@@ -923,11 +927,14 @@ c        note: WV has no hemlock data; uses EV coefficient
 
 c      note:   English-only on input and output
                                                                  
+c              JSP outside 3-5 will not set FDBT_C1, so we initialize it here.
+      FDBT_C1 = 0.0
+
       IF(JSP.EQ.3) THEN
         DMEDIAN = .566*(HTTOT-4.5)**( .634 + .00074*HTTOT)
         DFORM = DBHOB/DMEDIAN -1.0                                  
 
-  40    if (GEOSUB.EQ.'00') then
+        if (GEOSUB.EQ.'00') then
            RATIO = exp( -2.4641 + .04393*log(DBHOB) -.2922*dform
      >                 +.05964 * DFORM*log(DBHOB))
         else
@@ -942,7 +949,7 @@ c      note:   English-only on input and output
         FDBT_C1 = RATIO*DBHOB
         RETURN
       ELSEIF(JSP.EQ.4) THEN
-  50    if (GEOSUB.EQ.'00') then
+        if (GEOSUB.EQ.'00') then
            RATIO = .04504*(1.0 +0.8307*exp(-.2048*DBHOB))  
         else                                           
           DO 200, ID=1,8


### PR DESCRIPTION
## Summary

Clears 70 gfortran `-Wall` warnings in `f_west.f` (67 `-Wconversion`, 2 `-Wunused-label`, 1 `-Wmaybe-uninitialized`). These updates produce no numerical change. Outputs are bit-identical across a sweep of test cases for the Flewelling westside model implemented on the fork of this repo.

## The warning

```
f_west.f:57:38: Warning: Change of value in conversion from 'REAL(8)' to 'REAL(4)' [-Wconversion]
f_west.f:119:10: Warning: Possible change of value in conversion from REAL(8) to REAL(4) [-Wconversion]
f_west.f:930:4:  Warning: Label 40 at (1) defined but not used [-Wunused-label]
f_west.f:968:72: Warning: '__result_fdbt_c1' may be used uninitialized [-Wmaybe-uninitialized]
```

Three distinct patterns:

1. **`DATA` literals (32).** `SHP_W3` and `SHP_W4` declare their regional coefficient tables as `REAL*4 r25(8), r34(8)` but fill them with `d0` double-precision literals. gfortran flags each literal because the stored single-precision value differs in binary from the double it was written as.
2. **Narrowing stores (35).** These routines use `IMPLICIT DOUBLE PRECISION (A-H,O-Z)` for intermediates while the public  interface (`RFLW`, `RHFW`, `Z`, `DIBact`) is `REAL*4`. Every store back across that boundary is an implicit narrowing conversion. The output variables were all declared as REAL*4. so no precision is being lost compared to current behavior, just making that narrowing explicit.
3. **`FDBT_C1`** has branches for `JSP` 3, 4 and 5 but no `ELSE`, so any other `JSP` returns with the function result never assigned. Labels `40` and `50` inside it are branch targets nothing jumps to.

## The fixes

**1. `DATA` literals — single-precision suffixes.**

Before:
```fortran
      real*4 m1, m2, m3, R25(8), R34(8)
      data (r25(i),i=1,8)/   -2.0262D0, -1.7945d0, -2.0366d0,
     >         -2.0811d0, -1.9868d0, -2.0151d0, -1.9475d0, -2.0151d0 /
```

After:
```fortran
      real*4 m1, m2, m3, R25(8), R34(8)
      data (r25(i),i=1,8)/   -2.0262E0, -1.7945e0, -2.0366e0,
     >         -2.0811e0, -1.9868e0, -2.0151e0, -1.9475e0, -2.0151e0 /
```

The stored value is unchanged: rounding the decimal to `REAL*4` directly gives the same bit pattern as rounding it to `REAL*8` first and then narrowing. I checked all 32 literals — none is a double-rounding boundary case.

**2. Narrowing stores — explicit `REAL()`.**

Before:
```fortran
      R1= dexp(U1)/ (1.0d0 + dexp(U1))
      A3=U6
      Z  = GAMMA + DELTA*LOG(Y/(1.0d0-Y))
```

After:
```fortran
      R1= REAL(dexp(U1)/ (1.0d0 + dexp(U1)))
      A3=REAL(U6)
      Z  = REAL(GAMMA + DELTA*LOG(Y/(1.0d0-Y)))
```

This makes the existing narrowing explicit. The arithmetic is untouched — in particular the `D0` literals inside `COR_WS`'s expressions are left as-is, since dropping them would change the expression's evaluation precision rather than just its final conversion.

**3. `FDBT_C1` — initialize the result; drop the dead labels.**

```fortran
c              JSP outside 3-5 will not set FDBT_C1, so we initialize it here.
      FDBT_C1 = 0.0
```

Callers only ever pass `JSP` 3–5 (`sf_shp.f`), so no reachable behavior changes; the out-of-range path simply becomes deterministic instead of returning whatever was on the stack.

One warning is intentionally left: `geosub` is unused in `SHP_W5` because western redcedar has no regional coefficients. It can be dropped from the signature and still operate, but doing so would disrupt the pattern that `sf_shp.f` calls `SHP_W3`, `SHP_W4` and `SHP_W5` through one uniform interface, so a comment explaining that was added instead.

## Test evidence

The westside Flewelling path had no automated coverage on the fork, so new tests were added first, then used to verify the code updates proposed here.

| Check | Result |
|-------|--------|
| Automated tests | 47/47 passed, including 33 new Flewelling westside cases (equations `F00`–`F08` `FW2`/`FW3` × Douglas-fir 202, western hemlock 263, western redcedar 242) |
| Values compared | All 15 `vol[]` outputs over 7,290 input combinations (9 GEOSUB × 3 species × 3 model paths × 10 diameters × 9 heights), before vs. after |
| Tolerance | **Exact** — bit-for-bit identical on every value; no tolerance needed |
| Coverage confirmed | Verified the comparison actually reaches the edited lines: gcov shows 4,860 executions of each `SHP_W3/W4/W5` store and 4,320 of the `r25`/`r34` lookups, and deliberately perturbing the `SF_ZFD3`/`SF_ZFD4` stores and the `r25`/`r34` tables changes 3,240 and 507 cases respectively |
| Fork CI run | `lint`, `test`, `warnings` jobs — see the fork PR linked below |

## How to reproduce

```
gfortran -Wall -c f_west.f -o /dev/null
```

Before: 71 warnings. After: 1 (the documented `geosub` dummy argument).

## Additional context

- Fork development PR: `d-diaz/VolumeLibrary#14`
- This PR is source-only; baselines and tooling live on the fork.

Two latent issues were found while working here and are **not** touched by this PR — happy to file them as issues if useful:

- `SHP_W4` reads `f(48)` at line 263, but that routine's `DATA` statements only initialize `f(45)`–`f(47)`. Static storage means it currently reads as zero, so behaviour is stable, but the intended coefficient appears to be missing. I did not guess a value, since any substitution would change results.
- In `FDBT_C1`, `RATIO` is assigned only inside `IF(GCODE(ID).EQ.GEOSUB)` within the `DO 100`/`DO 200` loops, so a `GEOSUB` matching none of `'01'`–`'08'` leaves it unset. gfortran does not flag this one.