### PR TITLE
Fix REAL(8) to REAL(4) conversion warnings in f_other.f

### DIFF
--- a/f_other.f
+++ b/f_other.f
@@ -67,7 +67,7 @@ c                                      R3 PONDEROSA PINE
       C3 = BK(6,JSPR)
       D0 = BK(7,JSPR)
       D1 = BK(8,JSPR)
-	D2 = BK(9,JSPR)
+      D2 = BK(9,JSPR)
 
 c**********************************************************************
 C      IF(HT2.LT.(THT-2.0)) THEN
@@ -83,7 +83,7 @@ c         if DBTBH is missing, then calculate
       IF (DBTBH.LE.0) THEN
         IF(JSPR.LE.1) THEN
 c                      Black Hills
-           DBHIB = DBHOB*(D0+D1*ALOG(DBHOB))
+           DBHIB = REAL(DBHOB*(D0+D1*ALOG(DBHOB)))
         ELSE IF(JSPR.EQ.2) THEN
 c                      San Juan Model
            IF(GEOSUB.EQ.'07') THEN
@@ -92,7 +92,7 @@ C                 Use Dixie bark model
 C               DBHIB = -0.789251+0.922976*DBHOB
            ELSEIF(GEOSUB.EQ.'13')THEN
 C                 Use San Juan bark model 
-               DBHIB = DBHOB*(D0+D1*ALOG(DBHOB))
+               DBHIB = REAL(DBHOB*(D0+D1*ALOG(DBHOB)))
            ELSE IF(GEOSUB.EQ.'01') THEN
 C                 Use A-S, Gila bark model           
                DBHIB = -0.649171195+0.925582344*DBHOB
@@ -102,7 +102,7 @@ C                 Use region wide bark model
            ENDIF
         ELSE IF(JSPR.EQ.3) THEN
 c                      Dixie Model
-           DBHIB = DBHOB*(D0+D1*ALOG(DBHOB))
+           DBHIB = REAL(DBHOB*(D0+D1*ALOG(DBHOB)))
 
         ELSEIF (JSPR.EQ.4) THEN
 c                            R2 Lodgepole model
@@ -110,20 +110,20 @@ c                            R2 Lodgepole model
                DBHIB = DBHOB*(0.925915+0.0153361 * alog(DBHOB))
            ELSE
 C                          Northern Wyoming Bark Model
-               DBHIB = DBHOB*(D0 + D1*ALOG(DBHOB))
+               DBHIB = REAL(DBHOB*(D0 + D1*ALOG(DBHOB)))
            ENDIF
         ELSE IF(JSPR.EQ.5)THEN
 C                     Douglas Fir
-               DBHIB = D0 + D1*DBHOB
+               DBHIB = REAL(D0 + D1*DBHOB)
         ELSE IF(JSPR.EQ.6)THEN
 C                     White fir
-               DBHIB = D0 + D1*DBHOB
+               DBHIB = REAL(D0 + D1*DBHOB)
         ELSE IF(JSPR.EQ.7)THEN
 c                     Aspen Model
-               DBHIB = D0 + D1*DBHOB
+               DBHIB = REAL(D0 + D1*DBHOB)
         ELSE IF(JSPR.EQ.8)THEN
 C                     r3 ponderosa pine
-               DBHIB = D0 + D1*DBHOB + D2*DBHOB*DBHOB
+               DBHIB = REAL(D0 + D1*DBHOB + D2*DBHOB*DBHOB)
         ENDIF
         DBTBH = DBHOB - DBHIB
       ELSE
@@ -155,7 +155,7 @@ c         Use Wenzel non-lin stump model
       ENDIF
 C     ENDIF
 
-      DBT = PY * DBTBH
+      DBT = REAL(PY * DBTBH)
 
       DIB = DOB - DBT
          
@@ -353,28 +353,28 @@ c                                              limits on U1 to U5
 
 c                                         Define geometric parameters
 c                                        (These outcomes are SINGLE precision)
-      R1= dexp(U1)/ (1.0d0 + dexp(U1))                             
-      R2= dexp(U2)/ (1.0d0 + dexp(U2))                             
-      R3= dexp(U3)/ (1.0d0 + dexp(U3))                             
-      R4= dexp(U4)/ (1.0d0 + dexp(U4))                             
+      R1= REAL(dexp(U1)/ (1.0d0 + dexp(U1)))
+      R2= REAL(dexp(U2)/ (1.0d0 + dexp(U2)))
+      R3= REAL(dexp(U3)/ (1.0d0 + dexp(U3)))
+      R4= REAL(dexp(U4)/ (1.0d0 + dexp(U4)))
       IF (U5 .le. 7.0d0) then
-          R5= 0.5d0 + 0.5d0*dexp(U5)/ (1.0d0 + dexp(U5))                        
+          R5= REAL(0.5d0 + 0.5d0*dexp(U5)/ (1.0d0 + dexp(U5)))
         else
           R5=1.0
         endif
 
-      A3=U6
-      RHI1 =  dexp(U7) / ( 1.0d0 + dexp(U7) )
+      A3=REAL(U6)
+      RHI1 =  REAL(dexp(U7) / ( 1.0d0 + dexp(U7) ))
       if (RHI1.gt. 0.5 ) RHI1=0.5 
 
-      RHLONGI= U9    
+      RHLONGI= REAL(U9)
       RHI2 = RHI1 + RHLONGI
 
 c      RHC = RHI2 + (1.0D0 - RHI2) * dexp(U8)/( 1.0d0 + dexp(U8))
 c      If (RHC .lt. RHI2 +0.01) then
 c          RHC = MIN( RHI2+0.01, (RHI2+1.0)/2.0 )
 c        endif
-      RHC=U8 
+      RHC=REAL(U8)
       if (RHC .lt. RHI2+.01) RHC= min( RHI2+.01, (RHI2+1.)/2.0 )
 
 C     PUT COEFFICIENTS INTO AN ARRAY FOR EASIER PASSING
@@ -474,8 +474,8 @@ c                             define heights h1 and h2 with h2 > h1
 c                                         both heights are above BH
        t3=(h1-bh)/(HTTOT-bh)
        t4=(h2-bh)/(HTTOT-bh)                                
-       CORR = exp( q1*(t4-t3) + q2*(t4*t4-t3*t3)/2.0D0
-     >                  +q3*(t4*t4*t4 - t3*t3*t3)/3.0D0)     
+       CORR = REAL(exp( q1*(t4-t3) + q2*(t4*t4-t3*t3)/2.0D0
+     >                  +q3*(t4*t4*t4 - t3*t3*t3)/3.0D0))
        GO TO 100
       endif
 
@@ -483,8 +483,8 @@ c                                         both heights are above BH
 c                                              h1 < Bh  and h2 > BH
          t3=(h2-bh)/(HTTOT-bh)                             
          T2 = (BH-H1)/BH    
-         CORR = q5*exp( q4*t2 + q1*t3 +q2*t3*t3/2.0d0 
-     >                    +q3*t3**3 / 3.0d0 )       
+         CORR = REAL(q5*exp( q4*t2 + q1*t3 +q2*t3*t3/2.0d0
+     >                    +q3*t3**3 / 3.0d0 ))
          go to 100
         endif
 
@@ -492,7 +492,7 @@ c                                              h1 < Bh and H2 < Bh
 c                                              note: t2 < t1
        T2 = (BH-H2)/BH                                                   
        T1 = (BH-H1)/BH                                                   
-       CORR=exp( q4* (t1-t2))        
+       CORR=REAL(exp( q4* (t1-t2)))
 
 C100    IF (  abs(CORR) .gt. 1.0  .and.  ier_UNIT.ne.0) 
 C     1     write(IER_UNIT,102) JSP, H1,H2, CORR
@@ -610,24 +610,24 @@ C     REGION 3 PONDEROSA PINE
 
       JSPR = JSP - 22
 
-      VA00 = V(1, JSPR)
-      VA01 = V(2, JSPR)
-      VA02 = V(3, JSPR)
-      VB00 = V(4, JSPR)
-      VB01 = V(5, JSPR)
-      VC0  = V(6, JSPR)
+      VA00 = REAL(V(1, JSPR))
+      VA01 = REAL(V(2, JSPR))
+      VA02 = REAL(V(3, JSPR))
+      VB00 = REAL(V(4, JSPR))
+      VB01 = REAL(V(5, JSPR))
+      VC0  = REAL(V(6, JSPR))
       
-      VX1  = V(7,JSPR)
-      VX2  = V(8,JSPR)
-      VX3  = V(9,JSPR)
+      VX1  = REAL(V(7,JSPR))
+      VX2  = REAL(V(8,JSPR))
+      VX3  = REAL(V(9,JSPR))
 
-      VA03 = V(10, JSPR)
-      VE00 = V(11, JSPR)
-      VE01 = V(12, JSPR)
-      VE02 = V(13, JSPR)
-      VF00 = V(14, JSPR)
-      VF01 = V(15, JSPR)
-      VG0  = V(16, JSPR) 
+      VA03 = REAL(V(10, JSPR))
+      VE00 = REAL(V(11, JSPR))
+      VE01 = REAL(V(12, JSPR))
+      VE02 = REAL(V(13, JSPR))
+      VF00 = REAL(V(14, JSPR))
+      VF01 = REAL(V(15, JSPR))
+      VG0  = REAL(V(16, JSPR))
                           
       BH = 4.5
       
@@ -635,10 +635,10 @@ C     REGION 3 PONDEROSA PINE
       DRATIO = DBHOB/DMEDIAN 
       LOGHT = log(HTTOT)
 
-       VA0 = VA00 + VA01*LOGHT + VA02*DRATIO  + VA03*LOGHT*DRATIO
+       VA0 = REAL(VA00 + VA01*LOGHT + VA02*DRATIO  + VA03*LOGHT*DRATIO)
        VB0 = VB00 + VB01*LOGHT
 
-       VE0 = VE00 + VE01*LOGHT + VE02*DRATIO
+       VE0 = REAL(VE00 + VE01*LOGHT + VE02*DRATIO)
        VF0 = VF00 + VF01*LOGHT
 
        VC = VC0 + VX1*LOGHT 
@@ -746,22 +746,22 @@ c                                              limits on U1 to U5
       if (u9.lt. 0.0d0)  U9 = 0.0d0
 
 c     This code taken from RF_SHP2 from the REG1 program
-      R1 =  dexp(U1) / ( 1.0d0 + dexp(U1) )
-      R2 =  dexp(U2) / ( 1.0d0 + dexp(U2) )
-      R3 =  dexp(U3) / ( 1.0d0 + dexp(U3) )
-      R4 =  dexp(U4) / ( 1.0d0 + dexp(U4) )
-      R5 =  0.5 + 0.5*dexp(U5) / ( 1.0d0 + dexp(U5) )
+      R1 =  REAL(dexp(U1) / ( 1.0d0 + dexp(U1) ))
+      R2 =  REAL(dexp(U2) / ( 1.0d0 + dexp(U2) ))
+      R3 =  REAL(dexp(U3) / ( 1.0d0 + dexp(U3) ))
+      R4 =  REAL(dexp(U4) / ( 1.0d0 + dexp(U4) ))
+      R5 =  REAL(0.5 + 0.5*dexp(U5) / ( 1.0d0 + dexp(U5) ))
       
       IF (U5 .gt. 7.0) R5 = 1.0
       
-      a3 = U6
-      RHI1 =  dexp(U7) / ( 1.0d0 + dexp(U7) )
+      a3 = REAL(U6)
+      RHI1 =  REAL(dexp(U7) / ( 1.0d0 + dexp(U7) ))
       
       IF (RHI1.GT. 0.5) RHI1=0.5
       
-      RHLONGI = U9    
+      RHLONGI = REAL(U9)
       RHI2 = RHI1 + RHLONGI
-      RHC = U8
+      RHC = REAL(U8)
       IF (RHC.LT.RHI2+0.01) RHC = MIN(RHI2 + 0.01,
      >                                         (RHI2 + 1.0)/2.0)
       RHFW(1) = RHI1     
@@ -822,8 +822,8 @@ c                             define heights h1 and h2 with h2 > h1
 c                                         both heights are above BH
           T3=(H1-4.5)/(HTTOT-4.5)
           T4=(H2-4.5)/(HTTOT-4.5)                                
-          COR_BH = exp( Q1 * (T4 - T3) + Q2 * (T4*T4 - T3*T3)/2.0d0 +
-     >          Q3 * (T4*T4*T4 - T3*T3*T3)/3.0d0) 
+          COR_BH = REAL(exp( Q1*(T4 - T3) + Q2*(T4*T4-T3*T3)/2.0d0 +
+     >          Q3 * (T4*T4*T4 - T3*T3*T3)/3.0d0))
           IF(COR_BH.GT.0.999)  COR_BH = 0.999
           RETURN
       ENDIF
@@ -832,8 +832,8 @@ c                                         both heights are above BH
 c                                              h1 < Bh  and h2 > BH
          T3 = (H2 - 4.5)/(HTTOT - 4.5)                             
          T2 = (4.5 - H1)/4.5   
-         COR_BH = Q5 * exp( Q4 * T2 + Q1 * T3 + Q2*T3*T3/2.0d0 +
-     >            Q3*T3*T3*T3 / 3.0d0)       
+         COR_BH = REAL(Q5 * exp( Q4 * T2 + Q1 * T3 + Q2*T3*T3/2.0d0 +
+     >            Q3*T3*T3*T3 / 3.0d0))
          IF(COR_BH .GT. 0.999) COR_BH = 0.999
          IF(COR_BH .LT.-0.999) COR_BH = -0.999
          RETURN
@@ -845,7 +845,7 @@ c                                              note: t2 < t1
        T1 = (4.5 - H1)/4.5                                                   
        CORR = exp( Q4 * (T1-T2))        
       
-       COR_BH = CORR
+       COR_BH = REAL(CORR)
       RETURN
 
       END    
@@ -873,15 +873,15 @@ c
                  
 c                                                     below BH
       IF (HUP .LT. 4.5) THEN 
-         LVARHAT = -.15512542D+01-.82366251*HUP +.10190777*DBHOB
+         LVARHAT = REAL(-.15512542D+01-.82366251*HUP+.10190777*DBHOB)
          VARHAT = exp(LVARHAT)
 c                                                     above breast height
       ELSEIF (HUP .GT. 4.5) THEN
          
          RH = (HUP - 4.5)/(HTTOT - 4.5)
-         LVARHAT = (-.72335700D+01 + .22333875D+01*LOG(DBHOB)) +
+         LVARHAT = REAL((-.72335700D+01 + .22333875D+01*LOG(DBHOB)) +
      >             (.25870429D+01-.43950365D-01*LOG(DBHOB)) *
-     >             RH**(-.57411597D+00 + .67914946D+00*log(DBHOB))
+     >             RH**(-.57411597D+00 + .67914946D+00*log(DBHOB)))
          VARHAT = exp(LVARHAT)
 c                                                     at breast height
       ELSE


### PR DESCRIPTION
## Summary

Clears all 54 gfortran `-Wall` warnings in `f_other.f` (53 `-Wconversion`, 1 `-Wtabs`) by making the already-intended narrowing conversions explicit with `REAL()` and replacing one hard tab with spaces. **No numerical change** — verified bit-identical over a 12,960-case sweep. Warning cleanup only.

## The warning

All 53 conversion warnings are byte-identical apart from position:

```
f_other.f:613:13: Warning: Possible change of value in conversion from REAL(8) to REAL(4) [-Wconversion]
f_other.f:356:10: Warning: Possible change of value in conversion from REAL(8) to REAL(4) [-Wconversion]
f_other.f:876:19: Warning: Possible change of value in conversion from REAL(8) to REAL(4) [-Wconversion]
```

plus one driver-level warning:

```
f951: Warning: Nonconforming tab character in column 1 of line 70 [-Wtabs]
```

Each conversion site stores a `REAL*8` coefficient or intermediate into a `REAL*4` scalar. gfortran flags the implicit narrowing because it can silently lose precision. Here the narrowing is deliberate — the source says so at `f_other.f:355`, immediately above nine of the sites:

```fortran
c                                        (These outcomes are SINGLE precision)
```

The distribution across the file's seven compile units:

| Unit | Warnings |
|---|---:|
| `BRK_OT` | 9 |
| `SHP_OT` | 9 |
| `COR_OT` | 3 |
| `VAR_OT` | 18 |
| `SHP_BH` | 9 |
| `COR_BH` | 3 |
| `VAR_BH` | 2 |

## The fix

One edit class: wrap the right-hand side in `REAL()` at the point of assignment.

Coefficient unpack (`VAR_OT`, 34 sites of this shape):

```fortran
-      VA00 = V(1, JSPR)
+      VA00 = REAL(V(1, JSPR))
```

Multi-line expression — the closing paren goes on the continuation line (`COR_OT`, `COR_BH`):

```fortran
-       CORR = exp( q1*(t4-t3) + q2*(t4*t4-t3*t3)/2.0D0
-     >                  +q3*(t4*t4*t4 - t3*t3*t3)/3.0D0)
+       CORR = REAL(exp( q1*(t4-t3) + q2*(t4*t4-t3*t3)/2.0D0
+     >                  +q3*(t4*t4*t4 - t3*t3*t3)/3.0D0))
```

And the tab at line 70:

```fortran
-<TAB>D2 = BK(9,JSPR)
+      D2 = BK(9,JSPR)
```

**This is a provable no-op:** the compiler already emitted exactly this conversion. The declarations are unchanged, so the stored value is the same `REAL(4)` rounding of the same `REAL(8)` expression — `REAL()` only states in source what the compiler was doing silently. That is the whole semantic argument; the sweep below is confirmation, not the proof.

**What was deliberately not changed:**

- No declaration widening (`REAL*4` → `REAL*8`) — that *would* change results.
- No reflowing or inserted lines. Every edit is in place on an existing line: the file is 905 lines before and after, and the diff is 60 insertions / 60 deletions.
- `VAR_BH:876,882` are **not** rewritten from `D+01` to `E+01`. Those literals sit in an arithmetic expression, not a `DATA` initializer, so the double literal promotes the whole expression to double precision; respelling them as `E+01` would evaluate in single precision and *can* move results. They are wrapped in `REAL()` and left otherwise alone.

A few lines needed minor internal spacing tightened (e.g. `Q1 * (T4 - T3)` → `Q1*(T4 - T3)`) purely to keep the statement within fixed-form column 72 after adding `REAL(`.

## Test evidence

| Check | Result |
|-------|--------|
| Automated tests | 74/74 passed, including 20 new golden cases that specifically exercise this file |
| Values compared | **Bit-identical** (IEEE-754 byte comparison, not a tolerance) on all 15 returned volume components across 12,960 cases |
| Tolerance | None needed — exact equality |
| Warning count | `f_other.f` 54 → 0; repo total 2,038 → 1,984; no new warnings anywhere |

Details:

- **Sweep.** The pre-edit and post-edit shared libraries were loaded side by side and called with identical inputs over 12,960 cases: all 18 equation strings that dispatch into this file (`JSP` 22–29, covering Regions 2, 3, 4/Dixie and the Black Hills NF) crossed with a grid of dbh (6–45 in), total height (25–140 ft), merchantable tops, stump height, and upper-stem point. Every one of the 15 `vol[]` components matched bit for bit, as did `errflag`.
- **The sweep harness was itself validated.** Perturbing a single `BK` coefficient in its sixth decimal place (`0.699678` → `0.699679`) produced 1,160 mismatches, confirming the comparison detects changes at the level being claimed.
- **New tests.** 20 golden cases were added covering every `JSP` 22–29 route, both the 2-point and 3-point entry paths, and each region-specific bark sub-model. A gcov build confirmed these 20 cases execute **all 53** edited lines — so the bit-identity result covers every line touched, not just the file in aggregate.

## How to reproduce

With nothing but a stock gfortran, confirm the warnings are gone:

```
gfortran -Wall -c f_other.f -o /dev/null
```

Before this change that prints 54 warnings; after, none.

## Additional context

Not required reading to review this PR:

- This change is source-only. Test goldens, warning baselines, and build tooling live on the development fork and are not proposed here.
- Fork development PR: [d-diaz/VolumeLibrary#17](https://github.com/d-diaz/VolumeLibrary/pull/17)
- Fork CI run: [view logs here](https://github.com/d-diaz/VolumeLibrary/actions/runs/31204834121) — the `warnings` job shows the 54 → 0 drop; the `test` job's `Run pytest` step shows the 20 new `f_other_*` cases.
- This branch is cut from `upstream/master` (release 20260731). `f_other.f` there is byte-identical to the file the fix was developed and tested against, so the diff below is exactly the change that was verified.

## Separate issues that should be considered for later resolution (not fixed here)

While working in this file found issues whose fixes would each change numerical output. None belong in a no-op warning PR. Happy to open issues or follow-up PRs if useful:

1. **`BK` loses precision at initialization.** `BK(9,8)` is `REAL*8` (`f_other.f:24`) but its `DATA` literals carry no exponent letter, so 28 values with 8+ significant digits are truncated to single precision before being widened — `12.88990159` stores as `12.8899002…`. gfortran cannot see this; the widening itself is lossless.
2. **`DBHIB` can be used uninitialized.** `f_other.f:84-127` is an `IF`/`ELSE IF` chain with no `ELSE`, so a `JSPR` outside 1–8 reaches `DBTBH = DBHOB - DBHIB` at line 128 with `DBHIB` unset.
3. **Unguarded division.** Line 140 divides by `DBTBH`, which line 128 can leave at 0; `B2-DR**B3` is likewise unguarded. An in-source `DW 08/22` comment at line 137 proposes a filter, and line 139 implements it for `DR` only.
4. **Dispatch guards exceed the coefficient arrays.** `sf_shp.f:48`, `sf_corr.f:22` and `sf_dfz.f:18` guard `JSP.LE.30` → `JSPR = JSP-22`, reaching 8 against 7-column `F`/`V`; `brk_up.f:10` and `calcdia.f:535` guard `JSP.LE.30` → `JSPR = JSP-21`, reaching 9 against `BK(9,8)`. `fwinit.f:157-235` only ever emits 22–29, so this is latent, not live.
5. **Stale comments.** `f_other.f:578` labels the `V(*,5)` block `REGION 2 WHITE PINE` while lines 48, 253 and 431 all call index 5 *White fir*. `fwinit.f:340-364`'s JSP→model table omits 28, 29 and 33–36.